### PR TITLE
Simplify download links by using downloadURL directly

### DIFF
--- a/app/components/sections/Hero.tsx
+++ b/app/components/sections/Hero.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import { useLatestRelease } from "@/app/hooks/useLatestRelease";
 import { Button } from "@/components/ui/button";
+import { downloadURL } from "@/lib/utils";
 import { Download, Play } from "lucide-react";
 
 export default function Hero() {
-  const { downloadUrl } = useLatestRelease();
   return (
     <section className="relative min-h-screen flex items-center overflow-hidden pt-24 lg:pt-28">
       {/* Content */}
@@ -30,7 +29,7 @@ export default function Hero() {
 
           {/* CTA Buttons */}
           <div className="flex items-center justify-center gap-4 mb-6">
-            <Button variant="outline" onClick={() => window.open(downloadUrl, "_blank")}>
+            <Button variant="outline" onClick={() => window.open(downloadURL, "_blank")}>
               <Download className="transition-transform group-hover:scale-110" />
               Download
             </Button>

--- a/app/components/sections/Pricing.tsx
+++ b/app/components/sections/Pricing.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { useLatestRelease } from "@/app/hooks/useLatestRelease";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
-import { siteUrl } from "@/lib/utils";
+import { downloadURL, siteUrl } from "@/lib/utils";
 import { ArrowRight, Check } from "lucide-react";
 
 const plans = [
@@ -62,7 +61,6 @@ const plans = [
 ];
 
 export default function Pricing() {
-  const { downloadUrl } = useLatestRelease();
   return (
     <section className="relative py-24" id="pricing">
       {/* Section intro */}
@@ -136,7 +134,7 @@ export default function Pricing() {
                       : "bg-card hover:bg-muted"
                   }`}
                   variant={plan.popular ? "default" : "outline"}
-                  onClick={i === 0 ? () => window.open(downloadUrl, "_blank") : plan.onClick}
+                  onClick={i === 0 ? () => window.open(downloadURL, "_blank") : plan.onClick}
                 >
                   {plan.cta}
                   <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" />


### PR DESCRIPTION
## Summary
- Removed useLatestRelease hook and replaced with direct usage of downloadURL variable
- Simplified download button implementation in Hero and Pricing components

## Changes
- Updated Hero.tsx to import and use downloadURL directly from utils
- Updated Pricing.tsx to import and use downloadURL directly from utils
- Removed dependency on useLatestRelease hook

## Benefits
- Cleaner, more straightforward code
- No unnecessary state management or loading states
- Direct link to GitHub releases latest page