### PR TITLE
feat(api): send bug reports to Discord

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,9 @@ POLAR_WEBHOOK_SECRET="your_polar_webhook_secret"
 UPSTASH_REDIS_REST_URL="your_upstash_redis_rest_url"
 UPSTASH_REDIS_REST_TOKEN="your_upstash_redis_rest_token"
 
+
+# Bug report delivery
+DISCORD_BUG_REPORT_WEBHOOK_URL="https://discord.com/api/webhooks/your_webhook_id/your_webhook_token"
 # Umami Analytics (optional)
 NEXT_PUBLIC_UMAMI_SCRIPT_URL="your_umami_script_url"
 NEXT_PUBLIC_UMAMI_WEBSITE_ID="your_umami_website_id"

--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,7 @@ UPSTASH_REDIS_REST_URL="your_upstash_redis_rest_url"
 UPSTASH_REDIS_REST_TOKEN="your_upstash_redis_rest_token"
 
 # Bug report delivery
+# Do not include query parameters; the API adds wait=true.
 DISCORD_BUG_REPORT_WEBHOOK_URL="https://discord.com/api/webhooks/your_webhook_id/your_webhook_token"
 
 # Umami Analytics (optional)

--- a/.env.example
+++ b/.env.example
@@ -10,9 +10,9 @@ POLAR_WEBHOOK_SECRET="your_polar_webhook_secret"
 UPSTASH_REDIS_REST_URL="your_upstash_redis_rest_url"
 UPSTASH_REDIS_REST_TOKEN="your_upstash_redis_rest_token"
 
-
 # Bug report delivery
 DISCORD_BUG_REPORT_WEBHOOK_URL="https://discord.com/api/webhooks/your_webhook_id/your_webhook_token"
+
 # Umami Analytics (optional)
 NEXT_PUBLIC_UMAMI_SCRIPT_URL="your_umami_script_url"
 NEXT_PUBLIC_UMAMI_WEBSITE_ID="your_umami_website_id"

--- a/app/api/v1/bug-reports/route.test.ts
+++ b/app/api/v1/bug-reports/route.test.ts
@@ -1,0 +1,201 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const redisMock = {
+  incr: vi.fn(),
+  expire: vi.fn(),
+};
+
+vi.mock('@/lib/redis', () => ({
+  redis: redisMock,
+}));
+
+const { POST } = await import('./route');
+
+const validEnvironment = {
+  appVersion: '1.12.2',
+  platform: 'macos',
+  osVersion: '15.4',
+  architecture: 'aarch64',
+  currentModel: 'base.en',
+  deviceId: 'device-123',
+  timestamp: '2026-04-28T12:00:00.000Z',
+};
+
+const validLatestLog = {
+  fileName: 'voicetypr-2026-04-28.log',
+  content: 'INFO latest app log line',
+  truncated: false,
+  statusNote: '',
+};
+
+function createRequest(body: unknown, headers: Record<string, string> = {}) {
+  return new NextRequest('https://voicetypr.com/api/v1/bug-reports', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-forwarded-for': '203.0.113.10',
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/v1/bug-reports', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.DISCORD_BUG_REPORT_WEBHOOK_URL = 'https://discord.test/webhook';
+    redisMock.incr.mockResolvedValue(1);
+    redisMock.expire.mockResolvedValue(1);
+    global.fetch = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }));
+  });
+
+  it('delivers a valid manual report to Discord', async () => {
+    const response = await POST(createRequest({
+      kind: 'manual',
+      name: 'Moin',
+      email: 'moin@example.com',
+      message: 'Upload tab stopped scrolling',
+      environment: validEnvironment,
+      latestLog: validLatestLog,
+    }));
+
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      data: { delivered: true },
+    });
+    expect(response.status).toBe(200);
+    expect(redisMock.incr).toHaveBeenCalledWith('bug-report:rate:203.0.113.10:device-123');
+    expect(redisMock.expire).toHaveBeenCalledWith(expect.any(String), 600);
+    expect(fetch).toHaveBeenCalledWith(
+      'https://discord.test/webhook?wait=true',
+      expect.objectContaining({ method: 'POST', body: expect.any(FormData) })
+    );
+
+    const formData = vi.mocked(fetch).mock.calls[0]![1]!.body as FormData;
+    const payload = JSON.parse(formData.get('payload_json') as string);
+    expect(payload.content).toBe('New VoiceTypr bug report');
+    expect(payload.allowed_mentions).toEqual({ parse: [] });
+    expect(payload.attachments[0].filename).toBe('voicetypr-report.txt');
+  });
+
+  it('delivers a valid crash report to Discord', async () => {
+    const response = await POST(createRequest({
+      kind: 'crash',
+      message: 'It crashed after opening settings',
+      crash: {
+        errorMessage: 'Cannot read properties of undefined',
+        errorStack: 'Error stack',
+        componentStack: 'Component stack',
+      },
+      environment: validEnvironment,
+      latestLog: validLatestLog,
+    }));
+
+    await expect(response.json()).resolves.toMatchObject({ success: true });
+    expect(fetch).toHaveBeenCalledOnce();
+
+    const formData = vi.mocked(fetch).mock.calls[0]![1]!.body as FormData;
+    const payload = JSON.parse(formData.get('payload_json') as string);
+    expect(payload.content).toBe('New VoiceTypr crash report');
+    expect(payload.embeds[0].title).toBe('VoiceTypr crash report');
+  });
+
+  it('rejects invalid manual reports before rate limiting or Discord delivery', async () => {
+    const response = await POST(createRequest({
+      kind: 'manual',
+      message: '',
+      environment: validEnvironment,
+      latestLog: validLatestLog,
+    }));
+
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      error: 'parameter_validation_error',
+    });
+    expect(response.status).toBe(400);
+    expect(redisMock.incr).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('rate limits repeated callers', async () => {
+    redisMock.incr.mockResolvedValueOnce(6);
+
+    const response = await POST(createRequest({
+      kind: 'manual',
+      message: 'The app broke',
+      environment: validEnvironment,
+      latestLog: validLatestLog,
+    }));
+
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      error: 'rate_limited',
+    });
+    expect(response.status).toBe(429);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects reports with an oversized content-length before parsing', async () => {
+    const response = await POST(createRequest(
+      {
+        kind: 'manual',
+        message: 'The app broke',
+        environment: validEnvironment,
+        latestLog: validLatestLog,
+      },
+      { 'content-length': '100001' }
+    ));
+
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      error: 'payload_too_large',
+    });
+    expect(response.status).toBe(413);
+    expect(redisMock.incr).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('redacts diagnostic secrets before sending the Discord attachment', async () => {
+    await POST(createRequest({
+      kind: 'manual',
+      name: 'Moin',
+      email: 'moin@example.com',
+      message: 'My token is sk_test_1234567890abcdef and path /Users/moin/Library',
+      environment: validEnvironment,
+      latestLog: {
+        ...validLatestLog,
+        content: 'api_key=super-secret-value user test@example.com C:\\Users\\Moin\\AppData',
+      },
+    }));
+
+    const formData = vi.mocked(fetch).mock.calls[0]![1]!.body as FormData;
+    const file = formData.get('files[0]') as File;
+    const text = await file.text();
+
+    expect(text).toContain('[REDACTED_TOKEN]');
+    expect(text).toContain('api_key=[REDACTED_SECRET]');
+    expect(text).toContain('[REDACTED_EMAIL]');
+    expect(text).toContain('/Users/[REDACTED_USER]/Library');
+    expect(text).toContain('C:\\Users\\[REDACTED_USER]\\AppData');
+    expect(text).not.toContain('sk_test_1234567890abcdef');
+    expect(text).not.toContain('super-secret-value');
+  });
+
+  it('returns an internal error when Discord delivery fails', async () => {
+    global.fetch = vi.fn().mockResolvedValue(new Response('bad webhook', { status: 500 }));
+
+    const response = await POST(createRequest({
+      kind: 'manual',
+      message: 'The app broke',
+      environment: validEnvironment,
+      latestLog: validLatestLog,
+    }));
+
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      error: 'internal_error',
+    });
+    expect(response.status).toBe(500);
+  });
+});

--- a/app/api/v1/bug-reports/route.test.ts
+++ b/app/api/v1/bug-reports/route.test.ts
@@ -144,6 +144,7 @@ describe('POST /api/v1/bug-reports', () => {
       error: 'rate_limited',
     });
     expect(response.status).toBe(429);
+    expect(response.headers.get('Retry-After')).toBe('600');
     expect(fetch).not.toHaveBeenCalled();
   });
 
@@ -163,6 +164,21 @@ describe('POST /api/v1/bug-reports', () => {
     });
     expect(response.status).toBe(429);
     expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('normalizes IPv6 colons in rate limit keys', async () => {
+    await POST(createRequest(
+      {
+        kind: 'manual',
+        message: 'The app broke',
+        environment: validEnvironment,
+        latestLog: validLatestLog,
+      },
+      { 'x-forwarded-for': '2001:db8::1' }
+    ));
+
+    expect(rateLimitEvalMock).toHaveBeenCalledWith(['bug-report:rate:2001_db8__1:device-123'], ['600']);
+    expect(rateLimitEvalMock).toHaveBeenCalledWith(['bug-report:rate:2001_db8__1'], ['600']);
   });
 
   it('rejects reports whose actual body is too large before rate limiting or Discord delivery', async () => {
@@ -224,7 +240,7 @@ describe('POST /api/v1/bug-reports', () => {
       environment: validEnvironment,
       latestLog: {
         ...validLatestLog,
-        content: 'api_key=super-secret-value user test@example.com D:\\Users\\Moin\\AppData AKIA1234567890ABCDEF hf_abcdefghijklmnopqrstuvwxyz123456 Bearer abcdefghijklmnopqrstuvwxyz',
+        content: 'api_key=super-secret-value user test@example.com D:\\Users\\Moin\\AppData /root/.cache AKIA1234567890ABCDEF hf_abcdefghijklmnopqrstuvwxyz123456 Bearer abcdefghijklmnopqrstuvwxyz',
       },
     }));
 
@@ -237,6 +253,7 @@ describe('POST /api/v1/bug-reports', () => {
     expect(text).toContain('[REDACTED_EMAIL]');
     expect(text).toContain('/Users/[REDACTED_USER]/Library');
     expect(text).toContain('[REDACTED_DRIVE]:\\Users\\[REDACTED_USER]\\AppData');
+    expect(text).toContain('/[REDACTED_USER]/.cache');
     expect(text).not.toContain('sk_test_1234567890abcdef');
     expect(text).not.toContain('super-secret-value');
     expect(text).toContain('[REDACTED_AWS_KEY]');

--- a/app/api/v1/bug-reports/route.test.ts
+++ b/app/api/v1/bug-reports/route.test.ts
@@ -41,10 +41,22 @@ function createRequest(body: unknown, headers: Record<string, string> = {}) {
   });
 }
 
+function createRawRequest(body: string, headers: Record<string, string> = {}) {
+  return new NextRequest('https://voicetypr.com/api/v1/bug-reports', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-forwarded-for': '203.0.113.10',
+      ...headers,
+    },
+    body,
+  });
+}
+
 describe('POST /api/v1/bug-reports', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env.DISCORD_BUG_REPORT_WEBHOOK_URL = 'https://discord.test/webhook';
+    process.env.DISCORD_BUG_REPORT_WEBHOOK_URL = 'https://discord.com/api/webhooks/test-id/test-token';
     rateLimitEvalMock.mockResolvedValue(1);
     global.fetch = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }));
   });
@@ -65,8 +77,9 @@ describe('POST /api/v1/bug-reports', () => {
     });
     expect(response.status).toBe(200);
     expect(rateLimitEvalMock).toHaveBeenCalledWith(['bug-report:rate:203.0.113.10:device-123'], ['600']);
+    expect(rateLimitEvalMock).toHaveBeenCalledWith(['bug-report:rate:203.0.113.10'], ['600']);
     expect(fetch).toHaveBeenCalledWith(
-      'https://discord.test/webhook?wait=true',
+      'https://discord.com/api/webhooks/test-id/test-token?wait=true',
       expect.objectContaining({ method: 'POST', body: expect.any(FormData) })
     );
 
@@ -117,7 +130,7 @@ describe('POST /api/v1/bug-reports', () => {
   });
 
   it('rate limits repeated callers', async () => {
-    rateLimitEvalMock.mockResolvedValueOnce(6);
+    rateLimitEvalMock.mockResolvedValueOnce(6).mockResolvedValueOnce(1);
 
     const response = await POST(createRequest({
       kind: 'manual',
@@ -134,14 +147,63 @@ describe('POST /api/v1/bug-reports', () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
+  it('rate limits callers even when they rotate device identifiers', async () => {
+    rateLimitEvalMock.mockResolvedValueOnce(1).mockResolvedValueOnce(21);
+
+    const response = await POST(createRequest({
+      kind: 'manual',
+      message: 'The app broke',
+      environment: { ...validEnvironment, deviceId: 'rotated-device' },
+      latestLog: validLatestLog,
+    }));
+
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      error: 'rate_limited',
+    });
+    expect(response.status).toBe(429);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it('rejects reports whose actual body is too large before rate limiting or Discord delivery', async () => {
+    const response = await POST(createRawRequest(JSON.stringify({
+      kind: 'manual',
+      message: 'x'.repeat(100_001),
+      environment: validEnvironment,
+      latestLog: validLatestLog,
+    })));
+
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      error: 'payload_too_large',
+    });
+    expect(response.status).toBe(413);
+    expect(rateLimitEvalMock).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed JSON as a validation error', async () => {
+    const response = await POST(createRawRequest('{not json'));
+
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      error: 'parameter_validation_error',
+      message: 'Invalid JSON.',
+    });
+    expect(response.status).toBe(400);
+    expect(rateLimitEvalMock).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects reports with an oversized content-length before reading the body', async () => {
     const response = await POST(createRequest(
       {
         kind: 'manual',
-        message: 'x'.repeat(100_001),
+        message: 'The app broke',
         environment: validEnvironment,
         latestLog: validLatestLog,
-      }
+      },
+      { 'content-length': '100001' }
     ));
 
     await expect(response.json()).resolves.toMatchObject({
@@ -197,6 +259,24 @@ describe('POST /api/v1/bug-reports', () => {
 
   it('returns an internal error when the Discord webhook env var is missing', async () => {
     delete process.env.DISCORD_BUG_REPORT_WEBHOOK_URL;
+
+    const response = await POST(createRequest({
+      kind: 'manual',
+      message: 'The app broke',
+      environment: validEnvironment,
+      latestLog: validLatestLog,
+    }));
+
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      error: 'internal_error',
+    });
+    expect(response.status).toBe(500);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('returns an internal error when the Discord webhook URL is not Discord-owned', async () => {
+    process.env.DISCORD_BUG_REPORT_WEBHOOK_URL = 'https://example.com/webhook';
 
     const response = await POST(createRequest({
       kind: 'manual',

--- a/app/api/v1/bug-reports/route.test.ts
+++ b/app/api/v1/bug-reports/route.test.ts
@@ -342,6 +342,23 @@ describe('POST /api/v1/bug-reports', () => {
     expect(response.headers.get('Access-Control-Allow-Headers')).toContain('Content-Type');
   });
 
+  it('returns an internal error when Discord fetch throws', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('network error'));
+
+    const response = await POST(createRequest({
+      kind: 'manual',
+      message: 'The app broke',
+      environment: validEnvironment,
+      latestLog: validLatestLog,
+    }));
+
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      error: 'internal_error',
+    });
+    expect(response.status).toBe(500);
+  });
+
   it('returns an internal error when Discord delivery fails', async () => {
     global.fetch = vi.fn().mockResolvedValue(new Response('bad webhook', { status: 500 }));
 

--- a/app/api/v1/bug-reports/route.test.ts
+++ b/app/api/v1/bug-reports/route.test.ts
@@ -224,7 +224,7 @@ describe('POST /api/v1/bug-reports', () => {
       environment: validEnvironment,
       latestLog: {
         ...validLatestLog,
-        content: 'api_key=super-secret-value user test@example.com C:\\Users\\Moin\\AppData',
+        content: 'api_key=super-secret-value user test@example.com D:\\Users\\Moin\\AppData AKIA1234567890ABCDEF hf_abcdefghijklmnopqrstuvwxyz123456 Bearer abcdefghijklmnopqrstuvwxyz',
       },
     }));
 
@@ -236,9 +236,13 @@ describe('POST /api/v1/bug-reports', () => {
     expect(text).toContain('api_key=[REDACTED_SECRET]');
     expect(text).toContain('[REDACTED_EMAIL]');
     expect(text).toContain('/Users/[REDACTED_USER]/Library');
-    expect(text).toContain('C:\\Users\\[REDACTED_USER]\\AppData');
+    expect(text).toContain('[REDACTED_DRIVE]:\\Users\\[REDACTED_USER]\\AppData');
     expect(text).not.toContain('sk_test_1234567890abcdef');
     expect(text).not.toContain('super-secret-value');
+    expect(text).toContain('[REDACTED_AWS_KEY]');
+    expect(text).toContain('Bearer [REDACTED_TOKEN]');
+    expect(text).not.toContain('AKIA1234567890ABCDEF');
+    expect(text).not.toContain('hf_abcdefghijklmnopqrstuvwxyz123456');
   });
 
   it('redacts OpenAI-style sk-proj tokens before delivery', async () => {
@@ -317,6 +321,8 @@ describe('POST /api/v1/bug-reports', () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+    expect(response.headers.get('Access-Control-Allow-Methods')).toContain('POST');
+    expect(response.headers.get('Access-Control-Allow-Headers')).toContain('Content-Type');
   });
 
   it('returns an internal error when Discord delivery fails', async () => {

--- a/app/api/v1/bug-reports/route.test.ts
+++ b/app/api/v1/bug-reports/route.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { NextRequest } from 'next/server';
 
+const rateLimitEvalMock = vi.fn();
 const redisMock = {
-  incr: vi.fn(),
-  expire: vi.fn(),
+  createScript: vi.fn(() => ({ eval: rateLimitEvalMock })),
 };
 
 vi.mock('@/lib/redis', () => ({
@@ -45,8 +45,7 @@ describe('POST /api/v1/bug-reports', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     process.env.DISCORD_BUG_REPORT_WEBHOOK_URL = 'https://discord.test/webhook';
-    redisMock.incr.mockResolvedValue(1);
-    redisMock.expire.mockResolvedValue(1);
+    rateLimitEvalMock.mockResolvedValue(1);
     global.fetch = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }));
   });
 
@@ -65,8 +64,7 @@ describe('POST /api/v1/bug-reports', () => {
       data: { delivered: true },
     });
     expect(response.status).toBe(200);
-    expect(redisMock.incr).toHaveBeenCalledWith('bug-report:rate:203.0.113.10:device-123');
-    expect(redisMock.expire).toHaveBeenCalledWith(expect.any(String), 600);
+    expect(rateLimitEvalMock).toHaveBeenCalledWith(['bug-report:rate:203.0.113.10:device-123'], ['600']);
     expect(fetch).toHaveBeenCalledWith(
       'https://discord.test/webhook?wait=true',
       expect.objectContaining({ method: 'POST', body: expect.any(FormData) })
@@ -114,12 +112,12 @@ describe('POST /api/v1/bug-reports', () => {
       error: 'parameter_validation_error',
     });
     expect(response.status).toBe(400);
-    expect(redisMock.incr).not.toHaveBeenCalled();
+    expect(rateLimitEvalMock).not.toHaveBeenCalled();
     expect(fetch).not.toHaveBeenCalled();
   });
 
   it('rate limits repeated callers', async () => {
-    redisMock.incr.mockResolvedValueOnce(6);
+    rateLimitEvalMock.mockResolvedValueOnce(6);
 
     const response = await POST(createRequest({
       kind: 'manual',
@@ -136,15 +134,14 @@ describe('POST /api/v1/bug-reports', () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
-  it('rejects reports with an oversized content-length before parsing', async () => {
+  it('rejects reports whose actual body is too large before rate limiting or Discord delivery', async () => {
     const response = await POST(createRequest(
       {
         kind: 'manual',
-        message: 'The app broke',
+        message: 'x'.repeat(100_001),
         environment: validEnvironment,
         latestLog: validLatestLog,
-      },
-      { 'content-length': '100001' }
+      }
     ));
 
     await expect(response.json()).resolves.toMatchObject({
@@ -152,7 +149,7 @@ describe('POST /api/v1/bug-reports', () => {
       error: 'payload_too_large',
     });
     expect(response.status).toBe(413);
-    expect(redisMock.incr).not.toHaveBeenCalled();
+    expect(rateLimitEvalMock).not.toHaveBeenCalled();
     expect(fetch).not.toHaveBeenCalled();
   });
 
@@ -180,6 +177,66 @@ describe('POST /api/v1/bug-reports', () => {
     expect(text).toContain('C:\\Users\\[REDACTED_USER]\\AppData');
     expect(text).not.toContain('sk_test_1234567890abcdef');
     expect(text).not.toContain('super-secret-value');
+  });
+
+  it('redacts OpenAI-style sk-proj tokens before delivery', async () => {
+    await POST(createRequest({
+      kind: 'manual',
+      message: 'token sk-proj-abcdefghijklmnopqrstuvwxyz1234567890',
+      environment: validEnvironment,
+      latestLog: validLatestLog,
+    }));
+
+    const formData = vi.mocked(fetch).mock.calls[0]![1]!.body as FormData;
+    const file = formData.get('files[0]') as File;
+    const text = await file.text();
+
+    expect(text).toContain('[REDACTED_TOKEN]');
+    expect(text).not.toContain('sk-proj-abcdefghijklmnopqrstuvwxyz1234567890');
+  });
+
+  it('returns an internal error when the Discord webhook env var is missing', async () => {
+    delete process.env.DISCORD_BUG_REPORT_WEBHOOK_URL;
+
+    const response = await POST(createRequest({
+      kind: 'manual',
+      message: 'The app broke',
+      environment: validEnvironment,
+      latestLog: validLatestLog,
+    }));
+
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      error: 'internal_error',
+    });
+    expect(response.status).toBe(500);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('returns an internal error when Redis rate limiting fails', async () => {
+    rateLimitEvalMock.mockRejectedValueOnce(new Error('redis down'));
+
+    const response = await POST(createRequest({
+      kind: 'manual',
+      message: 'The app broke',
+      environment: validEnvironment,
+      latestLog: validLatestLog,
+    }));
+
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      error: 'internal_error',
+    });
+    expect(response.status).toBe(500);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('responds to OPTIONS with CORS headers', async () => {
+    const { OPTIONS } = await import('./route');
+    const response = await OPTIONS();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
   });
 
   it('returns an internal error when Discord delivery fails', async () => {

--- a/app/api/v1/bug-reports/route.test.ts
+++ b/app/api/v1/bug-reports/route.test.ts
@@ -90,6 +90,19 @@ describe('POST /api/v1/bug-reports', () => {
     expect(payload.attachments[0].filename).toBe('voicetypr-report.txt');
   });
 
+  it('labels contact as not provided when manual reports omit name and email', async () => {
+    await POST(createRequest({
+      kind: 'manual',
+      message: 'Upload tab stopped scrolling',
+      environment: validEnvironment,
+      latestLog: validLatestLog,
+    }));
+
+    const formData = vi.mocked(fetch).mock.calls[0]![1]!.body as FormData;
+    const payload = JSON.parse(formData.get('payload_json') as string);
+    expect(payload.embeds[0].fields.find((field: { name: string }) => field.name === 'Contact')?.value).toBe('Not provided');
+  });
+
   it('delivers a valid crash report to Discord', async () => {
     const response = await POST(createRequest({
       kind: 'crash',

--- a/app/api/v1/bug-reports/route.ts
+++ b/app/api/v1/bug-reports/route.ts
@@ -6,6 +6,7 @@ import {
   handleInternalError,
   handleValidationError,
 } from '@/lib/api-utils';
+import { ERROR_MESSAGES, ErrorCode } from '@/lib/constants';
 import { redis } from '@/lib/redis';
 import { bugReportRequestSchema, type BugReportRequest } from '@/lib/types';
 
@@ -13,24 +14,29 @@ const RATE_LIMIT_WINDOW_SECONDS = 10 * 60;
 const RATE_LIMIT_MAX_REPORTS = 5;
 const DISCORD_WAIT_QUERY = 'wait=true';
 const MAX_REQUEST_BYTES = 100_000;
+const RATE_LIMIT_SCRIPT = redis.createScript<number>(`
+  local n = redis.call('INCR', KEYS[1])
+  if n == 1 then redis.call('EXPIRE', KEYS[1], ARGV[1]) end
+  return n
+`);
 
 export async function POST(request: NextRequest) {
   try {
-    const contentLength = Number(request.headers.get('content-length') || 0);
-    if (contentLength > MAX_REQUEST_BYTES) {
+    const bodyText = await request.text();
+    if (new TextEncoder().encode(bodyText).length > MAX_REQUEST_BYTES) {
       return withCorsHeaders(
         NextResponse.json(
           {
             success: false,
-            error: 'payload_too_large',
-            message: 'Report is too large. Please copy the report and contact support directly.',
+            error: ErrorCode.PAYLOAD_TOO_LARGE,
+            message: ERROR_MESSAGES[ErrorCode.PAYLOAD_TOO_LARGE],
           },
           { status: 413 }
         )
       );
     }
 
-    const body = await request.json();
+    const body = JSON.parse(bodyText);
     const validationResult = bugReportRequestSchema.safeParse(body);
 
     if (!validationResult.success) {
@@ -45,8 +51,8 @@ export async function POST(request: NextRequest) {
         NextResponse.json(
           {
             success: false,
-            error: 'rate_limited',
-            message: 'Too many reports. Please try again later.',
+            error: ErrorCode.RATE_LIMITED,
+            message: ERROR_MESSAGES[ErrorCode.RATE_LIMITED],
           },
           { status: 429 }
         )
@@ -71,11 +77,7 @@ async function checkRateLimit(request: NextRequest, report: BugReportRequest): P
   const ipPart = normalizeRateLimitPart(ipAddress);
   const key = `bug-report:rate:${ipPart}:${deviceId}`;
 
-  const count = await redis.incr(key);
-
-  if (count === 1) {
-    await redis.expire(key, RATE_LIMIT_WINDOW_SECONDS);
-  }
+  const count = await RATE_LIMIT_SCRIPT.eval([key], [String(RATE_LIMIT_WINDOW_SECONDS)]);
 
   return { allowed: count <= RATE_LIMIT_MAX_REPORTS };
 }
@@ -160,6 +162,7 @@ function buildDiscordEmbed(report: BugReportRequest) {
 }
 
 function formatContact(report: BugReportRequest): string {
+  // Contact is intentionally not redacted; it is the reply path the user chose to provide.
   const parts = [];
   if (report.name) parts.push(report.name);
   if (report.email) parts.push(report.email);
@@ -236,7 +239,8 @@ function formatFullReport(report: BugReportRequest): string {
 function redactDiagnosticText(value: string): string {
   return value
     .replace(/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi, '[REDACTED_EMAIL]')
-    .replace(/\b(?:sk|sk-ant|ghp|gho|github_pat)_[A-Za-z0-9_-]{16,}\b/g, '[REDACTED_TOKEN]')
+    .replace(/\b(?:sk|sk-ant|ghp|gho|github_pat)[_-][A-Za-z0-9_-]{16,}\b/g, '[REDACTED_TOKEN]')
+    .replace(/\bsk-[A-Za-z0-9_-]{20,}\b/g, '[REDACTED_TOKEN]')
     .replace(/\b(api[_-]?key|access[_-]?token|refresh[_-]?token|secret|license[_-]?key)\b\s*[:=]\s*[^\s,;]+/gi, '$1=[REDACTED_SECRET]')
     .replace(/\/Users\/[^/\s]+/g, '/Users/[REDACTED_USER]')
     .replace(/\/home\/[^/\s]+/g, '/home/[REDACTED_USER]')

--- a/app/api/v1/bug-reports/route.ts
+++ b/app/api/v1/bug-reports/route.ts
@@ -11,6 +11,7 @@ import { ERROR_MESSAGES, ErrorCode } from '@/lib/constants';
 import { redis } from '@/lib/redis';
 import { bugReportRequestSchema, type BugReportRequest } from '@/lib/types';
 
+// Per-device is the normal limit; per-IP is a harder backstop because device IDs are client supplied.
 const RATE_LIMIT_WINDOW_SECONDS = 10 * 60;
 const RATE_LIMIT_MAX_REPORTS = 5;
 const RATE_LIMIT_MAX_IP_REPORTS = 20;
@@ -42,7 +43,7 @@ export async function POST(request: NextRequest) {
         NextResponse.json(
           {
             success: false,
-            error: 'parameter_validation_error',
+            error: ErrorCode.PARAMETER_VALIDATION_ERROR,
             message: 'Invalid JSON.',
           },
           { status: 400 }
@@ -83,7 +84,6 @@ export async function OPTIONS() {
   return new Response(null, { status: 200, headers: getCorsHeaders() });
 }
 
-
 async function checkRateLimit(request: NextRequest, report: BugReportRequest): Promise<{ allowed: boolean }> {
   const ipAddress = getClientIp(request);
   const rawDeviceId = report.environment.deviceId || 'unknown-device';
@@ -103,6 +103,8 @@ async function checkRateLimit(request: NextRequest, report: BugReportRequest): P
 }
 
 function getClientIp(request: NextRequest): string {
+  // Vercel/CDN sets this for production traffic; direct clients can spoof it, so Redis
+  // also keys by the client-provided device ID and uses an IP-only backstop.
   const forwardedFor = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim();
   return (
     forwardedFor ||

--- a/app/api/v1/bug-reports/route.ts
+++ b/app/api/v1/bug-reports/route.ts
@@ -12,6 +12,7 @@ import { bugReportRequestSchema, type BugReportRequest } from '@/lib/types';
 
 const RATE_LIMIT_WINDOW_SECONDS = 10 * 60;
 const RATE_LIMIT_MAX_REPORTS = 5;
+const RATE_LIMIT_MAX_IP_REPORTS = 20;
 const DISCORD_WAIT_QUERY = 'wait=true';
 const MAX_REQUEST_BYTES = 100_000;
 const RATE_LIMIT_SCRIPT = redis.createScript<number>(`
@@ -22,21 +23,31 @@ const RATE_LIMIT_SCRIPT = redis.createScript<number>(`
 
 export async function POST(request: NextRequest) {
   try {
+    const contentLength = Number(request.headers.get('content-length') || 0);
+    if (contentLength > MAX_REQUEST_BYTES) {
+      return withCorsHeaders(payloadTooLargeResponse());
+    }
+
     const bodyText = await request.text();
-    if (new TextEncoder().encode(bodyText).length > MAX_REQUEST_BYTES) {
+    if (Buffer.byteLength(bodyText, 'utf8') > MAX_REQUEST_BYTES) {
+      return withCorsHeaders(payloadTooLargeResponse());
+    }
+
+    let body: unknown;
+    try {
+      body = JSON.parse(bodyText);
+    } catch {
       return withCorsHeaders(
         NextResponse.json(
           {
             success: false,
-            error: ErrorCode.PAYLOAD_TOO_LARGE,
-            message: ERROR_MESSAGES[ErrorCode.PAYLOAD_TOO_LARGE],
+            error: 'parameter_validation_error',
+            message: 'Invalid JSON.',
           },
-          { status: 413 }
+          { status: 400 }
         )
       );
     }
-
-    const body = JSON.parse(bodyText);
     const validationResult = bugReportRequestSchema.safeParse(body);
 
     if (!validationResult.success) {
@@ -71,15 +82,34 @@ export async function OPTIONS() {
   return new Response(null, { status: 200, headers: getCorsHeaders() });
 }
 
+function payloadTooLargeResponse(): NextResponse {
+  // createErrorResponse currently omits the `error` field; desktop callers need it.
+  return NextResponse.json(
+    {
+      success: false,
+      error: ErrorCode.PAYLOAD_TOO_LARGE,
+      message: ERROR_MESSAGES[ErrorCode.PAYLOAD_TOO_LARGE],
+    },
+    { status: 413 }
+  );
+}
+
 async function checkRateLimit(request: NextRequest, report: BugReportRequest): Promise<{ allowed: boolean }> {
   const ipAddress = getClientIp(request);
-  const deviceId = normalizeRateLimitPart(report.environment.deviceId || 'unknown-device');
+  const rawDeviceId = report.environment.deviceId || 'unknown-device';
+  const deviceId = normalizeRateLimitPart(rawDeviceId);
   const ipPart = normalizeRateLimitPart(ipAddress);
-  const key = `bug-report:rate:${ipPart}:${deviceId}`;
+  const deviceKey = `bug-report:rate:${ipPart}:${deviceId}`;
+  const ipKey = `bug-report:rate:${ipPart}`;
 
-  const count = await RATE_LIMIT_SCRIPT.eval([key], [String(RATE_LIMIT_WINDOW_SECONDS)]);
+  const [deviceCount, ipCount] = await Promise.all([
+    RATE_LIMIT_SCRIPT.eval([deviceKey], [String(RATE_LIMIT_WINDOW_SECONDS)]),
+    RATE_LIMIT_SCRIPT.eval([ipKey], [String(RATE_LIMIT_WINDOW_SECONDS)]),
+  ]);
 
-  return { allowed: count <= RATE_LIMIT_MAX_REPORTS };
+  return {
+    allowed: deviceCount <= RATE_LIMIT_MAX_REPORTS && ipCount <= RATE_LIMIT_MAX_IP_REPORTS,
+  };
 }
 
 function getClientIp(request: NextRequest): string {
@@ -101,6 +131,10 @@ async function sendDiscordReport(report: BugReportRequest): Promise<void> {
 
   if (!webhookUrl) {
     throw new Error('DISCORD_BUG_REPORT_WEBHOOK_URL is not configured');
+  }
+
+  if (!webhookUrl.startsWith('https://discord.com/api/webhooks/')) {
+    throw new Error('DISCORD_BUG_REPORT_WEBHOOK_URL must be a Discord webhook URL');
   }
 
   const fullReport = formatFullReport(report);

--- a/app/api/v1/bug-reports/route.ts
+++ b/app/api/v1/bug-reports/route.ts
@@ -1,0 +1,248 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  getCorsHeaders,
+  withCorsHeaders,
+  createSuccessResponse,
+  handleInternalError,
+  handleValidationError,
+} from '@/lib/api-utils';
+import { redis } from '@/lib/redis';
+import { bugReportRequestSchema, type BugReportRequest } from '@/lib/types';
+
+const RATE_LIMIT_WINDOW_SECONDS = 10 * 60;
+const RATE_LIMIT_MAX_REPORTS = 5;
+const DISCORD_WAIT_QUERY = 'wait=true';
+const MAX_REQUEST_BYTES = 100_000;
+
+export async function POST(request: NextRequest) {
+  try {
+    const contentLength = Number(request.headers.get('content-length') || 0);
+    if (contentLength > MAX_REQUEST_BYTES) {
+      return withCorsHeaders(
+        NextResponse.json(
+          {
+            success: false,
+            error: 'payload_too_large',
+            message: 'Report is too large. Please copy the report and contact support directly.',
+          },
+          { status: 413 }
+        )
+      );
+    }
+
+    const body = await request.json();
+    const validationResult = bugReportRequestSchema.safeParse(body);
+
+    if (!validationResult.success) {
+      return withCorsHeaders(handleValidationError(validationResult.error));
+    }
+
+    const report = validationResult.data;
+    const rateLimit = await checkRateLimit(request, report);
+
+    if (!rateLimit.allowed) {
+      return withCorsHeaders(
+        NextResponse.json(
+          {
+            success: false,
+            error: 'rate_limited',
+            message: 'Too many reports. Please try again later.',
+          },
+          { status: 429 }
+        )
+      );
+    }
+
+    await sendDiscordReport(report);
+
+    return withCorsHeaders(createSuccessResponse({ delivered: true }, 'Report submitted'));
+  } catch (error) {
+    return withCorsHeaders(handleInternalError(error));
+  }
+}
+
+export async function OPTIONS() {
+  return new Response(null, { status: 200, headers: getCorsHeaders() });
+}
+
+async function checkRateLimit(request: NextRequest, report: BugReportRequest): Promise<{ allowed: boolean }> {
+  const ipAddress = getClientIp(request);
+  const deviceId = normalizeRateLimitPart(report.environment.deviceId || 'unknown-device');
+  const ipPart = normalizeRateLimitPart(ipAddress);
+  const key = `bug-report:rate:${ipPart}:${deviceId}`;
+
+  const count = await redis.incr(key);
+
+  if (count === 1) {
+    await redis.expire(key, RATE_LIMIT_WINDOW_SECONDS);
+  }
+
+  return { allowed: count <= RATE_LIMIT_MAX_REPORTS };
+}
+
+function getClientIp(request: NextRequest): string {
+  const forwardedFor = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim();
+  return (
+    forwardedFor ||
+    request.headers.get('cf-connecting-ip') ||
+    request.headers.get('x-real-ip') ||
+    'unknown-ip'
+  );
+}
+
+function normalizeRateLimitPart(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9_.:-]/g, '_').slice(0, 128) || 'unknown';
+}
+
+async function sendDiscordReport(report: BugReportRequest): Promise<void> {
+  const webhookUrl = process.env.DISCORD_BUG_REPORT_WEBHOOK_URL;
+
+  if (!webhookUrl) {
+    throw new Error('DISCORD_BUG_REPORT_WEBHOOK_URL is not configured');
+  }
+
+  const fullReport = formatFullReport(report);
+  const payload = {
+    username: 'VoiceTypr Reports',
+    content: report.kind === 'crash' ? 'New VoiceTypr crash report' : 'New VoiceTypr bug report',
+    allowed_mentions: { parse: [] },
+    embeds: [buildDiscordEmbed(report)],
+    attachments: [
+      {
+        id: 0,
+        filename: 'voicetypr-report.txt',
+        description: 'Full bounded VoiceTypr report including latest log excerpt',
+      },
+    ],
+  };
+
+  const formData = new FormData();
+  formData.append('payload_json', JSON.stringify(payload));
+  formData.append(
+    'files[0]',
+    new Blob([fullReport], { type: 'text/plain; charset=utf-8' }),
+    'voicetypr-report.txt'
+  );
+
+  const separator = webhookUrl.includes('?') ? '&' : '?';
+  const response = await fetch(`${webhookUrl}${separator}${DISCORD_WAIT_QUERY}`, {
+    method: 'POST',
+    body: formData,
+  });
+
+  if (!response.ok) {
+    const responseText = await response.text().catch(() => '');
+    throw new Error(`Discord webhook failed with ${response.status}: ${responseText.slice(0, 500)}`);
+  }
+}
+
+function buildDiscordEmbed(report: BugReportRequest) {
+  const environment = report.environment;
+  const title = report.kind === 'crash' ? 'VoiceTypr crash report' : 'VoiceTypr bug report';
+  const description = report.kind === 'crash'
+    ? truncate(redactDiagnosticText(report.crash.errorMessage), 1_000)
+    : truncate(redactDiagnosticText(report.message), 1_000);
+
+  return {
+    title,
+    description,
+    color: report.kind === 'crash' ? 0xef4444 : 0x3b82f6,
+    fields: [
+      { name: 'App Version', value: truncate(environment.appVersion, 1_024), inline: true },
+      { name: 'Platform', value: truncate(`${environment.platform} ${environment.osVersion}`, 1_024), inline: true },
+      { name: 'Architecture', value: truncate(environment.architecture, 1_024), inline: true },
+      { name: 'Model', value: truncate(environment.currentModel || 'None', 1_024), inline: true },
+      { name: 'Contact', value: truncate(formatContact(report), 1_024), inline: true },
+      { name: 'Log', value: truncate(formatLogSummary(report), 1_024), inline: false },
+    ],
+    timestamp: environment.timestamp,
+  };
+}
+
+function formatContact(report: BugReportRequest): string {
+  const parts = [];
+  if (report.name) parts.push(report.name);
+  if (report.email) parts.push(report.email);
+  return parts.length > 0 ? parts.join(' / ') : 'Not provided';
+}
+
+function formatLogSummary(report: BugReportRequest): string {
+  const latestLog = report.latestLog;
+  const source = latestLog.fileName || 'No file';
+  const truncation = latestLog.truncated ? 'truncated' : 'not truncated';
+  const status = latestLog.statusNote ? ` — ${latestLog.statusNote}` : '';
+  return `${source} (${latestLog.content.length} chars, ${truncation})${status}`;
+}
+
+function formatFullReport(report: BugReportRequest): string {
+  const lines: string[] = [];
+
+  lines.push(`# VoiceTypr ${report.kind === 'crash' ? 'Crash' : 'Bug'} Report`);
+  lines.push('');
+
+  if (report.name || report.email) {
+    lines.push('## Contact');
+    if (report.name) lines.push(`Name: ${report.name}`);
+    if (report.email) lines.push(`Email: ${report.email}`);
+    lines.push('');
+  }
+
+  if (report.kind === 'manual') {
+    lines.push('## Message');
+    lines.push(redactDiagnosticText(report.message));
+    lines.push('');
+  } else {
+    if (report.message) {
+      lines.push('## User Message');
+      lines.push(redactDiagnosticText(report.message));
+      lines.push('');
+    }
+
+    lines.push('## Crash');
+    lines.push(`Error: ${redactDiagnosticText(report.crash.errorMessage)}`);
+    if (report.crash.errorStack) {
+      lines.push('');
+      lines.push('### Stack');
+      lines.push(redactDiagnosticText(report.crash.errorStack));
+    }
+    if (report.crash.componentStack) {
+      lines.push('');
+      lines.push('### Component Stack');
+      lines.push(redactDiagnosticText(report.crash.componentStack));
+    }
+    lines.push('');
+  }
+
+  lines.push('## Environment');
+  lines.push(`App Version: ${report.environment.appVersion}`);
+  lines.push(`Platform: ${report.environment.platform}`);
+  lines.push(`OS Version: ${report.environment.osVersion}`);
+  lines.push(`Architecture: ${report.environment.architecture}`);
+  lines.push(`Current Model: ${report.environment.currentModel || 'None'}`);
+  lines.push(`Device ID: ${report.environment.deviceId || 'Unknown'}`);
+  lines.push(`Timestamp: ${report.environment.timestamp}`);
+  lines.push('');
+
+  lines.push('## Latest App Log');
+  if (report.latestLog.fileName) lines.push(`Source: ${report.latestLog.fileName}`);
+  if (report.latestLog.statusNote) lines.push(`Status: ${report.latestLog.statusNote}`);
+  if (report.latestLog.truncated) lines.push('Note: log was truncated before submission.');
+  lines.push('');
+  lines.push(redactDiagnosticText(report.latestLog.content) || '(No log content)');
+
+  return lines.join('\n');
+}
+
+function redactDiagnosticText(value: string): string {
+  return value
+    .replace(/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi, '[REDACTED_EMAIL]')
+    .replace(/\b(?:sk|sk-ant|ghp|gho|github_pat)_[A-Za-z0-9_-]{16,}\b/g, '[REDACTED_TOKEN]')
+    .replace(/\b(api[_-]?key|access[_-]?token|refresh[_-]?token|secret|license[_-]?key)\b\s*[:=]\s*[^\s,;]+/gi, '$1=[REDACTED_SECRET]')
+    .replace(/\/Users\/[^/\s]+/g, '/Users/[REDACTED_USER]')
+    .replace(/\/home\/[^/\s]+/g, '/home/[REDACTED_USER]')
+    .replace(/C:\\Users\\[^\\\s]+/gi, 'C:\\Users\\[REDACTED_USER]');
+}
+
+function truncate(value: string, maxLength: number): string {
+  return value.length <= maxLength ? value : `${value.slice(0, maxLength - 1)}…`;
+}

--- a/app/api/v1/bug-reports/route.ts
+++ b/app/api/v1/bug-reports/route.ts
@@ -16,8 +16,8 @@ const RATE_LIMIT_MAX_IP_REPORTS = 20;
 const DISCORD_WAIT_QUERY = 'wait=true';
 const MAX_REQUEST_BYTES = 100_000;
 const RATE_LIMIT_SCRIPT = redis.createScript<number>(`
+  redis.call('SET', KEYS[1], 0, 'EX', ARGV[1], 'NX')
   local n = redis.call('INCR', KEYS[1])
-  if n == 1 then redis.call('EXPIRE', KEYS[1], ARGV[1]) end
   return n
 `);
 
@@ -275,10 +275,13 @@ function redactDiagnosticText(value: string): string {
     .replace(/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi, '[REDACTED_EMAIL]')
     .replace(/\b(?:sk|sk-ant|ghp|gho|github_pat)[_-][A-Za-z0-9_-]{16,}\b/g, '[REDACTED_TOKEN]')
     .replace(/\bsk-[A-Za-z0-9_-]{20,}\b/g, '[REDACTED_TOKEN]')
+    .replace(/\bAKIA[0-9A-Z]{16}\b/g, '[REDACTED_AWS_KEY]')
+    .replace(/\bhf_[A-Za-z0-9]{32,}\b/g, '[REDACTED_TOKEN]')
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]{16,}\b/gi, 'Bearer [REDACTED_TOKEN]')
     .replace(/\b(api[_-]?key|access[_-]?token|refresh[_-]?token|secret|license[_-]?key)\b\s*[:=]\s*[^\s,;]+/gi, '$1=[REDACTED_SECRET]')
     .replace(/\/Users\/[^/\s]+/g, '/Users/[REDACTED_USER]')
     .replace(/\/home\/[^/\s]+/g, '/home/[REDACTED_USER]')
-    .replace(/C:\\Users\\[^\\\s]+/gi, 'C:\\Users\\[REDACTED_USER]');
+    .replace(/[A-Za-z]:\\Users\\[^\\\s]+/g, '[REDACTED_DRIVE]:\\Users\\[REDACTED_USER]');
 }
 
 function truncate(value: string, maxLength: number): string {

--- a/app/api/v1/bug-reports/route.ts
+++ b/app/api/v1/bug-reports/route.ts
@@ -3,6 +3,7 @@ import {
   getCorsHeaders,
   withCorsHeaders,
   createSuccessResponse,
+  createErrorResponse,
   handleInternalError,
   handleValidationError,
 } from '@/lib/api-utils';
@@ -25,12 +26,12 @@ export async function POST(request: NextRequest) {
   try {
     const contentLength = Number(request.headers.get('content-length') || 0);
     if (contentLength > MAX_REQUEST_BYTES) {
-      return withCorsHeaders(payloadTooLargeResponse());
+      return withCorsHeaders(createErrorResponse(ErrorCode.PAYLOAD_TOO_LARGE, 413));
     }
 
     const bodyText = await request.text();
     if (Buffer.byteLength(bodyText, 'utf8') > MAX_REQUEST_BYTES) {
-      return withCorsHeaders(payloadTooLargeResponse());
+      return withCorsHeaders(createErrorResponse(ErrorCode.PAYLOAD_TOO_LARGE, 413));
     }
 
     let body: unknown;
@@ -65,7 +66,7 @@ export async function POST(request: NextRequest) {
             error: ErrorCode.RATE_LIMITED,
             message: ERROR_MESSAGES[ErrorCode.RATE_LIMITED],
           },
-          { status: 429 }
+          { status: 429, headers: { 'Retry-After': String(RATE_LIMIT_WINDOW_SECONDS) } }
         )
       );
     }
@@ -82,17 +83,6 @@ export async function OPTIONS() {
   return new Response(null, { status: 200, headers: getCorsHeaders() });
 }
 
-function payloadTooLargeResponse(): NextResponse {
-  // createErrorResponse currently omits the `error` field; desktop callers need it.
-  return NextResponse.json(
-    {
-      success: false,
-      error: ErrorCode.PAYLOAD_TOO_LARGE,
-      message: ERROR_MESSAGES[ErrorCode.PAYLOAD_TOO_LARGE],
-    },
-    { status: 413 }
-  );
-}
 
 async function checkRateLimit(request: NextRequest, report: BugReportRequest): Promise<{ allowed: boolean }> {
   const ipAddress = getClientIp(request);
@@ -123,7 +113,7 @@ function getClientIp(request: NextRequest): string {
 }
 
 function normalizeRateLimitPart(value: string): string {
-  return value.toLowerCase().replace(/[^a-z0-9_.:-]/g, '_').slice(0, 128) || 'unknown';
+  return value.toLowerCase().replace(/[^a-z0-9_.-]/g, '_').slice(0, 128) || 'unknown';
 }
 
 async function sendDiscordReport(report: BugReportRequest): Promise<void> {
@@ -281,6 +271,7 @@ function redactDiagnosticText(value: string): string {
     .replace(/\b(api[_-]?key|access[_-]?token|refresh[_-]?token|secret|license[_-]?key)\b\s*[:=]\s*[^\s,;]+/gi, '$1=[REDACTED_SECRET]')
     .replace(/\/Users\/[^/\s]+/g, '/Users/[REDACTED_USER]')
     .replace(/\/home\/[^/\s]+/g, '/home/[REDACTED_USER]')
+    .replace(/\/root\//g, '/[REDACTED_USER]/')
     .replace(/[A-Za-z]:\\Users\\[^\\\s]+/g, '[REDACTED_DRIVE]:\\Users\\[REDACTED_USER]');
 }
 

--- a/app/api/v1/bug-reports/route.ts
+++ b/app/api/v1/bug-reports/route.ts
@@ -15,7 +15,6 @@ import { bugReportRequestSchema, type BugReportRequest } from '@/lib/types';
 const RATE_LIMIT_WINDOW_SECONDS = 10 * 60;
 const RATE_LIMIT_MAX_REPORTS = 5;
 const RATE_LIMIT_MAX_IP_REPORTS = 20;
-const DISCORD_WAIT_QUERY = 'wait=true';
 const MAX_REQUEST_BYTES = 100_000;
 const RATE_LIMIT_SCRIPT = redis.createScript<number>(`
   redis.call('SET', KEYS[1], 0, 'EX', ARGV[1], 'NX')
@@ -92,6 +91,10 @@ async function checkRateLimit(request: NextRequest, report: BugReportRequest): P
   const deviceKey = `bug-report:rate:${ipPart}:${deviceId}`;
   const ipKey = `bug-report:rate:${ipPart}`;
 
+  // Fail closed if Redis is unavailable. Reports keep the desktop Copy Report fallback,
+  // while allowing submission during a Redis outage would remove the only abuse guard.
+  // Both counters are incremented before the decision; the short fixed window keeps
+  // accidental shared-IP impact bounded while preserving one-round-trip atomicity.
   const [deviceCount, ipCount] = await Promise.all([
     RATE_LIMIT_SCRIPT.eval([deviceKey], [String(RATE_LIMIT_WINDOW_SECONDS)]),
     RATE_LIMIT_SCRIPT.eval([ipKey], [String(RATE_LIMIT_WINDOW_SECONDS)]),
@@ -139,7 +142,7 @@ async function sendDiscordReport(report: BugReportRequest): Promise<void> {
       {
         id: 0,
         filename: 'voicetypr-report.txt',
-        description: 'Full bounded VoiceTypr report including latest log excerpt',
+        description: 'VoiceTypr report including latest log excerpt',
       },
     ],
   };
@@ -153,7 +156,7 @@ async function sendDiscordReport(report: BugReportRequest): Promise<void> {
   );
 
   const separator = webhookUrl.includes('?') ? '&' : '?';
-  const response = await fetch(`${webhookUrl}${separator}${DISCORD_WAIT_QUERY}`, {
+  const response = await fetch(`${webhookUrl}${separator}wait=true`, {
     method: 'POST',
     body: formData,
   });

--- a/app/api/v1/bug-reports/route.ts
+++ b/app/api/v1/bug-reports/route.ts
@@ -272,7 +272,7 @@ function redactDiagnosticText(value: string): string {
     .replace(/\bsk-[A-Za-z0-9_-]{20,}\b/g, '[REDACTED_TOKEN]')
     .replace(/\bAKIA[0-9A-Z]{16}\b/g, '[REDACTED_AWS_KEY]')
     .replace(/\bhf_[A-Za-z0-9]{32,}\b/g, '[REDACTED_TOKEN]')
-    .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]{16,}\b/gi, 'Bearer [REDACTED_TOKEN]')
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]{16,}/gi, 'Bearer [REDACTED_TOKEN]')
     .replace(/\b(api[_-]?key|access[_-]?token|refresh[_-]?token|secret|license[_-]?key)\b\s*[:=]\s*[^\s,;]+/gi, '$1=[REDACTED_SECRET]')
     .replace(/\/Users\/[^/\s]+/g, '/Users/[REDACTED_USER]')
     .replace(/\/home\/[^/\s]+/g, '/home/[REDACTED_USER]')

--- a/lib/api-utils.ts
+++ b/lib/api-utils.ts
@@ -32,7 +32,7 @@ export function handleValidationError(error: ZodError): NextResponse<ApiResponse
   return NextResponse.json(
     {
       success: false,
-      error: 'parameter_validation_error',
+      error: ErrorCode.PARAMETER_VALIDATION_ERROR,
       message,
     },
     { status: 400 }

--- a/lib/api-utils.ts
+++ b/lib/api-utils.ts
@@ -15,11 +15,10 @@ export function createErrorResponse(
   error: ErrorCode,
   statusCode: number = 400
 ): NextResponse<ApiResponse> {
-
-
   return NextResponse.json(
     {
       success: false,
+      error,
       message: ERROR_MESSAGES[error],
     },
     { status: statusCode }

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -28,6 +28,10 @@ export enum ErrorCode {
   // Deactivation errors
   NOT_YOUR_LICENSE = 'not_your_license',
 
+  // Report errors
+  RATE_LIMITED = 'rate_limited',
+  PAYLOAD_TOO_LARGE = 'payload_too_large',
+
   // System errors
   INTERNAL_ERROR = 'internal_error',
   INVALID_DEVICE_HASH = 'invalid_device_hash',
@@ -48,6 +52,8 @@ export const ERROR_MESSAGES: Record<ErrorCode, string> = {
     'This license is active on another device. Deactivate it first.',
   [ErrorCode.DEVICE_MISMATCH]: 'This license is registered to a different device.',
   [ErrorCode.NOT_YOUR_LICENSE]: 'This license is not activated on this device.',
+  [ErrorCode.RATE_LIMITED]: 'Too many reports. Please try again later.',
+  [ErrorCode.PAYLOAD_TOO_LARGE]: 'Report is too large. Please copy the report and contact support directly.',
   [ErrorCode.INTERNAL_ERROR]: 'An internal error occurred. Please try again.',
   [ErrorCode.INVALID_DEVICE_HASH]: 'Invalid device identifier.',
   [ErrorCode.MISSING_DEVICE_HASH]: 'Device identifier is required.',

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -31,8 +31,8 @@ export enum ErrorCode {
   // Report errors
   RATE_LIMITED = 'rate_limited',
   PAYLOAD_TOO_LARGE = 'payload_too_large',
-
   PARAMETER_VALIDATION_ERROR = 'parameter_validation_error',
+
   // System errors
   INTERNAL_ERROR = 'internal_error',
   INVALID_DEVICE_HASH = 'invalid_device_hash',

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -32,6 +32,7 @@ export enum ErrorCode {
   RATE_LIMITED = 'rate_limited',
   PAYLOAD_TOO_LARGE = 'payload_too_large',
 
+  PARAMETER_VALIDATION_ERROR = 'parameter_validation_error',
   // System errors
   INTERNAL_ERROR = 'internal_error',
   INVALID_DEVICE_HASH = 'invalid_device_hash',
@@ -54,6 +55,7 @@ export const ERROR_MESSAGES: Record<ErrorCode, string> = {
   [ErrorCode.NOT_YOUR_LICENSE]: 'This license is not activated on this device.',
   [ErrorCode.RATE_LIMITED]: 'Too many reports. Please try again later.',
   [ErrorCode.PAYLOAD_TOO_LARGE]: 'Report is too large. Please copy the report and contact support directly.',
+  [ErrorCode.PARAMETER_VALIDATION_ERROR]: 'Invalid request parameters.',
   [ErrorCode.INTERNAL_ERROR]: 'An internal error occurred. Please try again.',
   [ErrorCode.INVALID_DEVICE_HASH]: 'Invalid device identifier.',
   [ErrorCode.MISSING_DEVICE_HASH]: 'Device identifier is required.',

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -38,6 +38,51 @@ export const licenseDeactivateRequestSchema = z.object({
   deviceHash: z.string().length(64).regex(/^[a-f0-9]{64}$/),
 });
 
+const optionalTrimmedString = (maxLength: number) =>
+  z.string().trim().max(maxLength).optional();
+
+const bugReportEnvironmentSchema = z.object({
+  appVersion: z.string().trim().min(1).max(32),
+  platform: z.string().trim().min(1).max(32),
+  osVersion: z.string().trim().min(1).max(128),
+  architecture: z.string().trim().min(1).max(64),
+  currentModel: z.string().trim().max(128).nullable().optional(),
+  deviceId: z.string().trim().max(128).optional(),
+  timestamp: z.string().datetime(),
+});
+
+const bugReportLatestLogSchema = z.object({
+  fileName: z.string().trim().max(255).nullable().optional(),
+  content: z.string().max(50_000),
+  truncated: z.boolean(),
+  statusNote: z.string().trim().max(500).optional(),
+});
+
+const bugReportBaseSchema = z.object({
+  name: optionalTrimmedString(100),
+  email: z.string().trim().email().max(254).optional(),
+  environment: bugReportEnvironmentSchema,
+  latestLog: bugReportLatestLogSchema,
+});
+
+export const bugReportRequestSchema = z.discriminatedUnion('kind', [
+  bugReportBaseSchema.extend({
+    kind: z.literal('manual'),
+    message: z.string().trim().min(1).max(10_000),
+  }),
+  bugReportBaseSchema.extend({
+    kind: z.literal('crash'),
+    message: optionalTrimmedString(10_000),
+    crash: z.object({
+      errorMessage: z.string().trim().min(1).max(5_000),
+      errorStack: z.string().max(20_000).optional(),
+      componentStack: z.string().max(10_000).optional(),
+    }),
+  }),
+]);
+
+export type BugReportRequest = z.infer<typeof bugReportRequestSchema>;
+
 // Response types
 export interface ApiResponse<T = unknown> {
   success: boolean;


### PR DESCRIPTION
## Summary
- add `POST /api/v1/bug-reports` for manual and crash report intake
- validate report payloads, cap body size, rate-limit with Redis, and redact diagnostic text server-side
- deliver reports privately to Discord via `DISCORD_BUG_REPORT_WEBHOOK_URL` with mentions disabled
- fix `createErrorResponse` to include the `error` field consistently across API error responses

## Verification
- `pnpm vitest run app/api/v1/bug-reports/route.test.ts`
- `pnpm typecheck`
- `pnpm lint`

## Notes
Set `DISCORD_BUG_REPORT_WEBHOOK_URL` in the web deployment before wiring desktop Submit buttons to this endpoint. Use the Discord webhook URL, not a channel ID, and do not include query parameters.